### PR TITLE
Xml display

### DIFF
--- a/display_xml.py
+++ b/display_xml.py
@@ -40,13 +40,15 @@ class XML:
             Pygment style names (the default is 'default')
         '''
         if isinstance(in_obj, str):
-            self.text = in_obj.encode('utf-8')
-        elif isinstance(in_obj, et._Element):
-            self.text = et.tostring(in_obj)
+            self.xml = et.fromstring(in_obj)
+        elif isinstance(in_obj, bytes): 
+            self.xml = et.fromstring(in_obj)
         elif isinstance(in_obj, et._ElementTree):
-            self.text = et.tostring(in_obj.getroot())
-        else:  # assume isinstance(in_obj, bytes)
-            self.text = in_obj
+            self.xml = in_obj.getroot()
+        else:  # assume isinstance(in_obj, et._Element)
+            self.xml        
+            
+        self.text = et.tostring(self.xml, pretty_print=True)
         self.style = style
         self.formatter = HtmlFormatter(style=self.style)
         self.uuid_class = "a"+str(self.uuid)

--- a/display_xml.py
+++ b/display_xml.py
@@ -7,8 +7,7 @@ from uuid import uuid4
 
 from IPython.display import display
 
-
-
+no_blank_parser = et.XMLParser(remove_blank_text=True)
 
 
 class XML:
@@ -40,14 +39,14 @@ class XML:
             Pygment style names (the default is 'default')
         '''
         if isinstance(in_obj, str):
-            self.xml = et.fromstring(in_obj)
+            self.xml = et.fromstring(in_obj, parser=no_blank_parser)
         elif isinstance(in_obj, bytes): 
-            self.xml = et.fromstring(in_obj)
+            self.xml = et.fromstring(in_obj, parser=no_blank_parser)
         elif isinstance(in_obj, et._ElementTree):
             self.xml = in_obj.getroot()
         else:  # assume isinstance(in_obj, et._Element)
-            self.xml        
-            
+            self.xml
+        
         self.text = et.tostring(self.xml, pretty_print=True)
         self.style = style
         self.formatter = HtmlFormatter(style=self.style)
@@ -82,7 +81,6 @@ class XML:
                       template=cls.NAMED_STYLE_TEMPLATE, 
                       extras={"style_name": style}
                       ))
-        
     
     @property
     def style_css(self):

--- a/display_xml.py
+++ b/display_xml.py
@@ -1,23 +1,36 @@
 from pygments import highlight
 from pygments.lexers import XmlLexer
 from pygments.formatters import HtmlFormatter
+from pygments.styles import get_all_styles
 import lxml.etree as et
 from uuid import uuid4
 
-HTML_TEMPLATE = """<div class={}> <style>
-{}
-</style>
-{}
-</div>
-"""
+from IPython.display import display
+
+
+
 
 
 class XML:
     '''Class for displaying XML in a pretty way that supports pygments styles.
-
     '''
+    HTML_TEMPLATE = """
+    <div class={uuid_class}> 
+        <style>
+            {style_css}
+        </style>
+        {content}
+    </div>
+    """
+    
+    NAMED_STYLE_TEMPLATE = (
+        """<h3 style="margin-bottom:.3em"> {extras[style_name]} </h3>""" + 
+        HTML_TEMPLATE + 
+        "<hr/>"
+        )
 
-    def __init__(self, in_obj, style='default'):
+    def __init__(self, in_obj, style='default', template=HTML_TEMPLATE, 
+                 extras={}):
         '''
         Parameters
         ----------
@@ -37,7 +50,38 @@ class XML:
         self.style = style
         self.formatter = HtmlFormatter(style=self.style)
         self.uuid_class = "a"+str(self.uuid)
-
+        self.template = template
+        self.extras = extras
+    
+    @classmethod
+    def display_all_styles(cls, in_obj):
+        """
+        Displays all available pygments styles using XML.style_gen()
+        
+        Parameters
+        ----------
+        
+        in_obj: str lxml.etree._Element, lxml.ettree._ElementTree, or bytes
+            Object to be displayed as html
+        """
+        for disp in cls.style_gen(in_obj):
+            display(disp)
+                        
+    @classmethod
+    def style_gen(cls, in_obj):
+        """
+        Generator for iterating over all of the styles available from pygments.
+        
+        If you declare this xml = XML.style_gen(text), use next(xml).
+        """
+        for style in get_all_styles():
+            yield(cls(in_obj, 
+                      style=style, 
+                      template=cls.NAMED_STYLE_TEMPLATE, 
+                      extras={"style_name": style}
+                      ))
+        
+    
     @property
     def style_css(self):
         temp_css = self.formatter.get_style_defs()
@@ -50,4 +94,8 @@ class XML:
 
     def _repr_html_(self):
         content = highlight(self.text, XmlLexer(), self.formatter)
-        return HTML_TEMPLATE.format(self.uuid_class, self.style_css, content)
+        return self.template.format(uuid_class=self.uuid_class,
+                                    style_css=self.style_css,
+                                    content=content,
+                                    extras=self.extras
+    )


### PR DESCRIPTION
parses strings into etree objects before displaying. 

Uses the remove white space formatter in order to get good indentation properties.

Now has a method for displaying all of the possible styles and a generator (if you want to iterate through the styles one-by-one).